### PR TITLE
Supporting AWS, Azure and GCP in TfLint

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,17 @@
+plugin "aws" {
+    enabled = true
+    version = "0.12.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+plugin "google" {
+    enabled = true
+    version = "0.15.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-google"
+}
+
+plugin "azurerm" {
+    enabled = true
+    version = "0.14.0"
+    source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir -p ${BIN_DIR}
 ENV GOOS=linux
 ENV GOARCH=amd64
 WORKDIR /validiac
-COPY go.mod go.sum Makefile ./
+COPY go.mod go.sum Makefile .tflint.hcl ./
 RUN go mod download
 RUN make -e deps
 COPY backend/ ./backend/
@@ -17,4 +17,6 @@ FROM alpine:3.14
 RUN apk add -u ca-certificates git
 COPY --from=0 /validiac/bin/* /validiac/bin/
 ENV HOME="/validiac/bin/"
+ENV BIN_PATH="/validiac/bin/"
+RUN /validiac/bin/tflint --init -c /validiac/bin/.tflint.hcl
 ENTRYPOINT ["/bin/sh", "-c", "'/validiac/bin/validiac'"]

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 BIN_DIR := $(shell pwd)/bin
 UNAME_M := $(shell uname -m)
 UNAME_S := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+
 TFLINT_VERSION := 0.34.1
 INFRACOST_VERSION := 0.9.19
 TFSEC_VERSION := 1.5.0
 INFRAMAP_VERSION := 0.6.7
-TFLINT_EXEC := $(BIN_DIR)/tflint-$(TFLINT_VERSION)
-TFSEC_EXEC := $(BIN_DIR)/tfsec-$(TFSEC_VERSION)
-INFRAMAP_EXEC := $(BIN_DIR)/inframap-$(INFRAMAP_VERSION)
-INFRACOST_EXEC := $(BIN_DIR)/infracost-$(INFRACOST_VERSION)
+
+TFLINT_EXEC := $(BIN_DIR)/tflint
+TFSEC_EXEC := $(BIN_DIR)/tfsec
+INFRAMAP_EXEC := $(BIN_DIR)/inframap
+INFRACOST_EXEC := $(BIN_DIR)/infracost
 
 all: check build
 
@@ -31,6 +33,8 @@ endif
 $(TFLINT_EXEC): check
 	$(shell wget -O- https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_${UNAME_S}_amd64.zip | funzip > ${TFLINT_EXEC})
 	@chmod +x ${TFLINT_EXEC}
+	cp ./.tflint.hcl $(BIN_DIR)/.tflint.hcl
+	cp ./.tflint.hcl $(BIN_DIR)/.tflint.hcl
 
 $(TFSEC_EXEC): check
 	$(shell wget -O- https://github.com/aquasecurity/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-${UNAME_S}-amd64 > ${TFSEC_EXEC})
@@ -48,13 +52,13 @@ $(INFRAMAP_EXEC): check
 deps: $(TFLINT_EXEC) $(TFSEC_EXEC) $(INFRACOST_EXEC) $(INFRAMAP_EXEC)
 
 test:
-	go test -ldflags "-X github.com/gofireflyio/validiac/backend/api.TFLintExec=${TFLINT_EXEC} -X github.com/gofireflyio/validiac/backend/api.TFSecExec=${TFSEC_EXEC} -X github.com/gofireflyio/validiac/backend/api.InfraMapExec=${INFRAMAP_EXEC} -X github.com/gofireflyio/validiac/backend/api.InfraCostExec=${INFRACOST_EXEC}" ./...
+	go test ./...
 
 lint:
 	golangci-lint run ./...
 
 build:
-	CGO_ENABLED=0 go build -tags netgo -ldflags "-s -w -X github.com/gofireflyio/validiac/backend/api.TFLintExec=${TFLINT_EXEC} -X github.com/gofireflyio/validiac/backend/api.TFSecExec=${TFSEC_EXEC} -X github.com/gofireflyio/validiac/backend/api.InfraMapExec=${INFRAMAP_EXEC} -X github.com/gofireflyio/validiac/backend/api.InfraCostExec=${INFRACOST_EXEC}" -o ${BIN_DIR}/validiac backend/main.go
+	CGO_ENABLED=0 go build -tags netgo -o ${BIN_DIR}/validiac backend/main.go
 
 docker:
 	docker build -t gofireflyio/validiac:latest .

--- a/backend/api/api.go
+++ b/backend/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"io/ioutil"
+    "os"
 )
 
 type Tool string
@@ -44,4 +45,12 @@ func asTempDir(ext string, in []byte) (path string, err error) {
 	}
 
 	return dir, nil
+}
+
+func getEnv(key, defaultValue string) string {
+    value := os.Getenv(key)
+    if len(value) == 0 {
+        return defaultValue
+    }
+    return value
 }

--- a/backend/api/infracost.go
+++ b/backend/api/infracost.go
@@ -7,7 +7,7 @@ import (
     "os/exec"
 )
 
-var InfraCostExec = ""
+var InfraCostExec = getEnv("INFRACOST_EXEC", fmt.Sprintf("%s/infracost", BIN_PATH))
 
 func InfraCost(in []byte) ([]byte, error) {
     var infraCostApiKey = funk.GetOrElse(os.Getenv("INFRACOST_API_KEY"), "infracost-api-key")

--- a/backend/api/inframap.go
+++ b/backend/api/inframap.go
@@ -1,11 +1,12 @@
 package api
 
 import (
-	"os"
-	"os/exec"
+    "fmt"
+    "os"
+    "os/exec"
 )
 
-var InfraMapExec = ""
+var InfraMapExec = getEnv("INFRAMAP_EXEC",  fmt.Sprintf("%s/inframap", BIN_PATH))
 
 func InfraMap(in []byte) ([]byte, error) {
 	path, err := asTempFile("", "", in)

--- a/backend/api/init.go
+++ b/backend/api/init.go
@@ -1,0 +1,7 @@
+package api
+
+var BIN_PATH = getEnv("BIN_PATH", "./bin")
+
+func Init() ([]byte, error){
+    return tflintInit()
+}

--- a/backend/api/tflint.go
+++ b/backend/api/tflint.go
@@ -1,11 +1,18 @@
 package api
 
 import (
-	"os"
-	"os/exec"
+    "fmt"
+    "os"
+    "os/exec"
 )
 
-var TFLintExec = ""
+var TFLintExec = getEnv("TFLINT_EXEC", fmt.Sprintf("%s/tflint", BIN_PATH))
+var TFLintConfig = getEnv("TFLINT_config", fmt.Sprintf("%s/.tflint.hcl", BIN_PATH))
+
+func tflintInit() ([]byte, error){
+    var cmd = exec.Command(TFLintExec, "--init", "-c", TFLintConfig)
+    return cmd.CombinedOutput()
+}
 
 func TFLint(in []byte) ([]byte, error) {
 	path, err := asTempFile("", ".tf", in)
@@ -14,5 +21,5 @@ func TFLint(in []byte) ([]byte, error) {
 	}
 
 	defer os.Remove(path) // nolint: errcheck
-	return exec.Command(TFLintExec, "--enable-plugin=aws", path, "--no-color").CombinedOutput()
+    return exec.Command(TFLintExec, fmt.Sprintf("--config=%s", TFLintConfig), "--enable-plugin=aws", "--enable-plugin=azurerm", "--enable-plugin=google", path, "--no-color").CombinedOutput()
 }

--- a/backend/api/tfsec.go
+++ b/backend/api/tfsec.go
@@ -1,11 +1,12 @@
 package api
 
 import (
-	"os"
+    "fmt"
+    "os"
 	"os/exec"
 )
 
-var TFSecExec = ""
+var TFSecExec = getEnv("TFSEC_EXEC", fmt.Sprintf("%s/tfsec", BIN_PATH))
 
 func TFSec(in []byte) ([]byte, error) {
 	path, err := asTempDir(".tf", in)

--- a/backend/main.go
+++ b/backend/main.go
@@ -46,6 +46,11 @@ func main() {
 		// we are running in an AWS Lambda function
 		lambda.Start(router.Handler)
 	} else {
+        var _, err = api.Init()
+        if err != nil{
+            os.Stdout.Write([]byte("could not init binaries"))
+        }
+
 		// we are running from the command line
 		var cli struct {
 			Cmd  string `arg:"" optional:"" help:"Command to run (lint, secure, map, cost)"`


### PR DESCRIPTION
- Exec path is now passed through environment variable (InfraCost, TfLint, TfSec, InfraMap)
- Initializing TfLint while backend is up
- Initializing TfLint in Docker (for lambda)
- Reducing complexity from Makefile