### PR TITLE
Bugfix: png generation fails in a Lambda environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,12 @@ RUN make -e build && make -e test
 RUN chmod +x ./bin/validiac
 
 FROM alpine:3.14
-RUN apk add -u ca-certificates git graphviz
+RUN apk add -u ca-certificates git graphviz msttcorefonts-installer
+RUN update-ms-fonts && fc-cache -f
 COPY --from=0 /validiac/bin/* /validiac/bin/
 ENV HOME="/validiac/bin/"
 ENV BIN_PATH="/validiac/bin/"
 RUN /validiac/bin/tflint --init -c /validiac/bin/.tflint.hcl
+ENV XDG_CACHE_HOME="/tmp/.cache"
+ENV XDG_DATA_HOME="/tmp/.data"
 ENTRYPOINT ["/bin/sh", "-c", "'/validiac/bin/validiac'"]

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/alecthomas/kong v0.5.0
-	github.com/aquasecurity/lmdrouter v0.4.4
-	github.com/aws/aws-lambda-go v1.28.0
+	github.com/aquasecurity/lmdrouter v0.4.5-rc
+	github.com/aws/aws-lambda-go v1.29.0
 	github.com/gabriel-vasile/mimetype v1.4.0
 	github.com/hashicorp/hcl2 v0.0.0-20191002203319-fb75b3253c80
 	github.com/jgroeneveld/trial v2.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -10,9 +10,13 @@ github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2
 github.com/apparentlymart/go-textseg v1.0.0/go.mod h1:z96Txxhf3xSFMPmb5X/1W05FF/Nj9VFpLOpjS5yuumk=
 github.com/aquasecurity/lmdrouter v0.4.4 h1:wh0qHM7s74HFOZiINI3fsBYyquBTWpF1U+JrcJbR+dA=
 github.com/aquasecurity/lmdrouter v0.4.4/go.mod h1:vkF/ZqcXXUIcJXeAtUF867A/SHONd8MUw/+sy7uLXRA=
+github.com/aquasecurity/lmdrouter v0.4.5-rc h1:hruRrZTui+eG/drAwpaMagNviaN+vr5hyjy+3AEVh5A=
+github.com/aquasecurity/lmdrouter v0.4.5-rc/go.mod h1:vkF/ZqcXXUIcJXeAtUF867A/SHONd8MUw/+sy7uLXRA=
 github.com/aws/aws-lambda-go v1.15.0/go.mod h1:FEwgPLE6+8wcGBTe5cJN3JWurd1Ztm9zN4jsXsjzKKw=
 github.com/aws/aws-lambda-go v1.28.0 h1:fZiik1PZqW2IyAN4rj+Y0UBaO1IDFlsNo9Zz/XnArK4=
 github.com/aws/aws-lambda-go v1.28.0/go.mod h1:jJmlefzPfGnckuHdXX7/80O3BvUUi12XOkbv4w9SGLU=
+github.com/aws/aws-lambda-go v1.29.0 h1:u+sfZkvNBUgt0ZkO8Q/jOMBV22DqMDMbZu04oomM2no=
+github.com/aws/aws-lambda-go v1.29.0/go.mod h1:aakqVz9vDHhtbt0U2zegh/z9SI2+rJ+yRREZYNQLmWY=
 github.com/bsm/go-vlq v0.0.0-20150828105119-ec6e8d4f5f4e/go.mod h1:N+BjUcTjSxc2mtRGSCPsat1kze3CUtvJN3/jTXlp29k=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=


### PR DESCRIPTION
In an AWS Lambda container, no paths are writable except /tmp. When
generating PNGs via inframap/dot, the program attempted to write to
$XDG_CACHE_HOME, which was /validiac/bin/.cache, i.e. a non-writable
path. This commit fixes the issue by setting $XDG_CACHE_HOME to
/tmp/.cache instead.

In addition, core MS fonts are installed in the image so that Graphviz
can properly render text.

Also, the Lambda handlers will now encode output in base64 encoding when
the output is binary rather than textual. It should be noted that API
Gateway will only decode base64 responses for media types that were
defined in the API configuration's "Binary Media Type" list, and when
clients send appropriate Accept headers.