### PR TITLE
Always send --raw to inframap

### DIFF
--- a/backend/api/inframap.go
+++ b/backend/api/inframap.go
@@ -26,10 +26,7 @@ func InfraMap(in []byte, opts InfraMapOpts) ([]byte, error) {
 		"--show-icons=true",
 		"--connections=false",
 		"--clean=false",
-	}
-
-	if !opts.Png {
-		args = append(args, "--raw")
+		"--raw",
 	}
 
 	cmd := exec.Command(InfraMapExec, append(args, path)...)


### PR DESCRIPTION
The `--raw` flag was only sent to inframap if a png was not being
generated. This could result in empty graphs in some situations.