### PR TITLE
Upgrade Binaries

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,17 +1,17 @@
 plugin "aws" {
     enabled = true
-    version = "0.12.0"
+    version = "0.14.0"
     source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 
 plugin "google" {
     enabled = true
-    version = "0.15.0"
+    version = "0.18.0"
     source  = "github.com/terraform-linters/tflint-ruleset-google"
 }
 
 plugin "azurerm" {
     enabled = true
-    version = "0.14.0"
+    version = "0.17.0"
     source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
 }

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ BIN_DIR := $(shell pwd)/bin
 UNAME_M := $(shell uname -m)
 UNAME_S := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
-TFLINT_VERSION := 0.34.1
-INFRACOST_VERSION := 0.9.19
-TFSEC_VERSION := 1.5.0
+TFLINT_VERSION := 0.38.1
+INFRACOST_VERSION := 0.10.6
+TFSEC_VERSION := 1.26.0
 INFRAMAP_VERSION := 0.6.7
 
 TFLINT_EXEC := $(BIN_DIR)/tflint

--- a/backend/api/infracost.go
+++ b/backend/api/infracost.go
@@ -24,7 +24,6 @@ func InfraCost(in []byte) ([]byte, error) {
 		"breakdown",
 		"--path",
 		path,
-		"--terraform-parse-hcl",
 		"--no-color",
 		"--log-level=error",
 	)


### PR DESCRIPTION
TFLint - upgrade from 0.34.1 -> 0.38.1
        AWS Provider - upgrade from 0.12.0 -> 0.14.0
        GCP Provider - upgrade from 0.15.0 -> 0.18.0
        Azure Provider - upgrade from 0.14.0 -> 0.17.0
InfraCost - upgrade from 0.9.19 -> 0.10.6
TfSec - upgrade from 1.5.0 -> 1.26.0

In addition, Infracost deprecated terraform-parse-hcl flag